### PR TITLE
Continuous colormap

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,6 +1,7 @@
 ### History
 
 v2.8.0
+- Added support for continuous colormaps.
 - Added fast calculation mode for field statistics.
 - Simplified map settings panel.
 - Move symbology controls into popup.

--- a/src/gui_controller.py
+++ b/src/gui_controller.py
@@ -909,6 +909,9 @@ class GuiController(QObject):
         )
         self.ui.sb_symbol_value_offset.valueChanged.connect(self.setSymbologyOffset)
         self.ui.sb_symbol_classes.valueChanged.connect(self.applyLiveSymbology)
+        self.ui.cb_symbol_continuous_colormap.toggled.connect(
+            self.continuousColormapChanged
+        )
         self.ui.sb_symbol_size.valueChanged.connect(self.applyLiveSymbology)
         self.ui.sb_symbol_opacity.valueChanged.connect(self.applyLiveSymbology)
         self.ui.cb_symbology_live.toggled.connect(self.activateLiveSymbology)
@@ -1038,6 +1041,11 @@ class GuiController(QObject):
             self.msg_signal.emit("Range symmetry disabled.", 'i', 0)
         self.applyLiveSymbology()
 
+    def continuousColormapChanged(self, status):
+        """Apply one semantic discrete/continuous colormap mode change."""
+        self.insar_map.continuous_colormap = bool(status)
+        self.applyLiveSymbology()
+
     def setSymbologyOffset(self):
         self.insar_map.offset_value = self.ui.sb_symbol_value_offset.value()
         self.applyLiveSymbology()
@@ -1125,6 +1133,9 @@ class GuiController(QObject):
         self.insar_map.min_value = float(self.ui.sb_symbol_lower_range.value())
         self.insar_map.max_value = float(self.ui.sb_symbol_upper_range.value())
         self.insar_map.num_classes = int(self.ui.sb_symbol_classes.value())
+        self.insar_map.continuous_colormap = bool(
+            self.ui.cb_symbol_continuous_colormap.isChecked()
+        )
         self.insar_map.alpha = float(self.ui.sb_symbol_opacity.value()) / 100
         self.insar_map.symbol_size = float(self.ui.sb_symbol_size.value())
         self.insar_map.color_ramp_name = str(self.ui.cmb_colormap.currentData())

--- a/src/map_setting.py
+++ b/src/map_setting.py
@@ -431,8 +431,14 @@ class InsarMap:
 
     def setSymbologyRasterContinuous(self, layer, color_ramp):
         """Apply a genuinely interpolated raster shader for the active range."""
+        effective_min = float(self.min_value) + float(self.offset_value)
+        effective_max = float(self.max_value) + float(self.offset_value)
         shader = QgsRasterShader()
+        shader.setMinimumValue(effective_min)
+        shader.setMaximumValue(effective_max)
         color_ramp_shader = QgsColorRampShader()
+        color_ramp_shader.setMinimumValue(effective_min)
+        color_ramp_shader.setMaximumValue(effective_max)
         color_ramp_shader.setColorRampType(QgsColorRampShader.Interpolated)
 
         span = float(self.max_value) - float(self.min_value)
@@ -450,6 +456,8 @@ class InsarMap:
         color_ramp_shader.setColorRampType(QgsColorRampShader.Interpolated)
         shader.setRasterShaderFunction(color_ramp_shader)
         renderer = QgsSingleBandPseudoColorRenderer(layer.dataProvider(), 1, shader)
+        renderer.setClassificationMin(effective_min)
+        renderer.setClassificationMax(effective_max)
         layer.setRenderer(renderer)
         layer.triggerRepaint()
         self.iface.mapCanvas().refresh()
@@ -469,8 +477,6 @@ class InsarMap:
         symbol_layer = symbol.symbolLayer(0)
         if hasattr(symbol_layer, "setStrokeWidth"):
             symbol_layer.setStrokeWidth(self.stroke_width)
-        # Preserve the existing point/polygon outline convention. Line symbols
-        # use their stroke itself as the continuously transformed color.
         if int(layer.geometryType()) != 1 and hasattr(symbol_layer, "setStrokeColor"):
             symbol_layer.setStrokeColor(QColor("gray"))
 

--- a/src/map_setting.py
+++ b/src/map_setting.py
@@ -46,6 +46,7 @@ class InsarMap:
         self.num_classes = 9
         self.color_ramp_name = color_maps.DEFAULT_COLORMAP_ID
         self.color_ramp_reverse_flag = False
+        self.continuous_colormap = True
         self.data_type = "vector"
         self._std_statistics_cache = {}
         self._std_cache_connected_layer_ids = set()

--- a/src/map_setting.py
+++ b/src/map_setting.py
@@ -1,8 +1,18 @@
 import numpy as np
 from qgis.PyQt.QtGui import QColor
 from qgis.core import (
-    Qgis, QgsFeatureRequest, QgsGraduatedSymbolRenderer, QgsRectangle,
-    QgsRendererRange, QgsSymbol,
+    Qgis,
+    QgsColorRampTransformer,
+    QgsFeatureRequest,
+    QgsGradientColorRamp,
+    QgsGradientStop,
+    QgsGraduatedSymbolRenderer,
+    QgsProperty,
+    QgsRectangle,
+    QgsRendererRange,
+    QgsSingleSymbolRenderer,
+    QgsSymbol,
+    QgsSymbolLayer,
 )
 from qgis.core import QgsRasterShader, QgsColorRampShader, QgsSingleBandPseudoColorRenderer
 from osgeo import gdal
@@ -373,14 +383,115 @@ class InsarMap:
             max_length = max(len(f"{self.min_value:.2f}"), len(f"{self.max_value:.2f}"))
 
         if status_vector:
-            self.setSymbologyVector(layer, interval, max_length, color_ramp)
+            if self.continuous_colormap:
+                self.setSymbologyVectorContinuous(layer, color_ramp)
+            else:
+                self.setSymbologyVector(layer, interval, max_length, color_ramp)
             return ""
         elif status_raster:
-            self.setSymbologyRaster(layer, interval, max_length, color_ramp)
+            if self.continuous_colormap:
+                self.setSymbologyRasterContinuous(layer, color_ramp)
+            else:
+                self.setSymbologyRaster(layer, interval, max_length, color_ramp)
             return ""
         else:
             message = '<span style="color:red;">Could not set the symbology. Check layer validity.</span>'
             return message
+
+    @staticmethod
+    def _qgisGradientColorRamp(color_ramp):
+        """Convert the plugin ramp to a native smooth QGIS gradient ramp."""
+        stops = list(color_ramp.ramp)
+        if not stops:
+            return QgsGradientColorRamp()
+        if len(stops) == 1:
+            color = QColor(stops[0][1])
+            return QgsGradientColorRamp(color, color, False, [])
+
+        gradient_stops = [
+            QgsGradientStop(float(position), QColor(color))
+            for position, color in stops[1:-1]
+        ]
+        return QgsGradientColorRamp(
+            QColor(stops[0][1]),
+            QColor(stops[-1][1]),
+            False,
+            gradient_stops,
+        )
+
+    @staticmethod
+    def _symbolLayerColorProperty(geometry_type):
+        """Return the data-defined color property for one vector geometry type."""
+        property_name = "StrokeColor" if int(geometry_type) == 1 else "FillColor"
+        legacy_name = "Property{}".format(property_name)
+        legacy = getattr(QgsSymbolLayer, legacy_name, None)
+        if legacy is not None:
+            return legacy
+        return getattr(QgsSymbolLayer.Property, property_name)
+
+    def setSymbologyRasterContinuous(self, layer, color_ramp):
+        """Apply a genuinely interpolated raster shader for the active range."""
+        shader = QgsRasterShader()
+        color_ramp_shader = QgsColorRampShader()
+        color_ramp_shader.setColorRampType(QgsColorRampShader.Interpolated)
+
+        span = float(self.max_value) - float(self.min_value)
+        items = []
+        for position, ramp_color in color_ramp.ramp:
+            raw_value = float(self.min_value) + float(position) * span
+            value = raw_value + float(self.offset_value)
+            color = QColor(ramp_color)
+            color.setAlphaF(self.alpha)
+            items.append(
+                QgsColorRampShader.ColorRampItem(value, color, f"{raw_value:.2f}")
+            )
+
+        color_ramp_shader.setColorRampItemList(items)
+        color_ramp_shader.setColorRampType(QgsColorRampShader.Interpolated)
+        shader.setRasterShaderFunction(color_ramp_shader)
+        renderer = QgsSingleBandPseudoColorRenderer(layer.dataProvider(), 1, shader)
+        layer.setRenderer(renderer)
+        layer.triggerRepaint()
+        self.iface.mapCanvas().refresh()
+
+    def setSymbologyVectorContinuous(self, layer, color_ramp):
+        """Apply per-feature continuous ramp coloring through a QGIS transformer."""
+        field_name = self.selected_field_name
+        if field_name is None:
+            return "layer field name is None"
+
+        symbol = QgsSymbol.defaultSymbol(layer.geometryType())
+        if hasattr(symbol, "setSize"):
+            symbol.setSize(self.symbol_size)
+        if hasattr(symbol, "setOpacity"):
+            symbol.setOpacity(self.alpha)
+
+        symbol_layer = symbol.symbolLayer(0)
+        if hasattr(symbol_layer, "setStrokeWidth"):
+            symbol_layer.setStrokeWidth(self.stroke_width)
+        # Preserve the existing point/polygon outline convention. Line symbols
+        # use their stroke itself as the continuously transformed color.
+        if int(layer.geometryType()) != 1 and hasattr(symbol_layer, "setStrokeColor"):
+            symbol_layer.setStrokeColor(QColor("gray"))
+
+        property_value = QgsProperty.fromField(field_name)
+        property_value.setTransformer(
+            QgsColorRampTransformer(
+                float(self.min_value) + float(self.offset_value),
+                float(self.max_value) + float(self.offset_value),
+                self._qgisGradientColorRamp(color_ramp),
+            )
+        )
+        symbol_layer.setDataDefinedProperty(
+            self._symbolLayerColorProperty(layer.geometryType()),
+            property_value,
+        )
+
+        renderer = QgsSingleSymbolRenderer(symbol)
+        layer.setRenderer(renderer)
+        layer.triggerRepaint()
+        self.iface.mapCanvas().refresh()
+        return ""
 
     def setSymbologyRaster(self, layer, interval, max_length, color_ramp):
 

--- a/src/ui/map_settings/panel.py
+++ b/src/ui/map_settings/panel.py
@@ -109,6 +109,7 @@ QPushButton {
             self.cb_symbol_value_offset_sync_with_ref,
             self.cmb_colormap,
             self.pb_colormap_reverse,
+            self.cb_symbol_continuous_colormap,
             self.sb_symbol_classes,
             self.sb_symbol_size,
             self.sb_symbol_opacity,
@@ -160,6 +161,9 @@ QPushButton {
             self.sb_symbol_size,
             self.sb_symbol_opacity,
             self,
+        )
+        self.cb_symbol_continuous_colormap = (
+            self.symbology_settings_popup.cb_symbol_continuous_colormap
         )
 
         self.cb_symbology_live = QtWidgets.QCheckBox(self)

--- a/src/ui/map_settings/popup.py
+++ b/src/ui/map_settings/popup.py
@@ -105,7 +105,7 @@ class SymbologySettingsPopup(QtWidgets.QWidget):
         self.cb_symbol_continuous_colormap.setAccessibleName(
             "Continuous colormap"
         )
-        self.cb_symbol_continuous_colormap.setChecked(False)
+        self.cb_symbol_continuous_colormap.setChecked(True)
         self.cb_symbol_continuous_colormap.toggled.connect(
             self._sync_continuous_colormap_controls
         )
@@ -125,7 +125,9 @@ class SymbologySettingsPopup(QtWidgets.QWidget):
         layout.addLayout(form)
 
         self._form_layout = form
-        self._sync_continuous_colormap_controls(False)
+        self._sync_continuous_colormap_controls(
+            self.cb_symbol_continuous_colormap.isChecked()
+        )
         self.setMaximumWidth(280)
 
     def set_continuous_colormap(self, continuous):

--- a/src/ui/map_settings/popup.py
+++ b/src/ui/map_settings/popup.py
@@ -93,9 +93,27 @@ class SymbologySettingsPopup(QtWidgets.QWidget):
         self.sb_symbol_size = marker_size_spin_box
         self.sb_symbol_opacity = opacity_spin_box
 
+        self.cb_symbol_continuous_colormap = QtWidgets.QCheckBox(
+            "Continuous colormap", self
+        )
+        self.cb_symbol_continuous_colormap.setObjectName(
+            "cb_symbol_continuous_colormap"
+        )
+        self.cb_symbol_continuous_colormap.setToolTip(
+            "Use a continuously interpolated colormap"
+        )
+        self.cb_symbol_continuous_colormap.setAccessibleName(
+            "Continuous colormap"
+        )
+        self.cb_symbol_continuous_colormap.setChecked(False)
+        self.cb_symbol_continuous_colormap.toggled.connect(
+            self._sync_continuous_colormap_controls
+        )
+
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(9, 9, 9, 9)
         layout.setSpacing(6)
+        layout.addWidget(self.cb_symbol_continuous_colormap)
 
         form = QtWidgets.QFormLayout()
         form.setContentsMargins(0, 0, 0, 0)
@@ -107,4 +125,19 @@ class SymbologySettingsPopup(QtWidgets.QWidget):
         layout.addLayout(form)
 
         self._form_layout = form
+        self._sync_continuous_colormap_controls(False)
         self.setMaximumWidth(280)
+
+    def set_continuous_colormap(self, continuous):
+        """Set continuous mode programmatically and synchronize dependent UI."""
+        continuous = bool(continuous)
+        blocked = self.cb_symbol_continuous_colormap.blockSignals(True)
+        try:
+            self.cb_symbol_continuous_colormap.setChecked(continuous)
+        finally:
+            self.cb_symbol_continuous_colormap.blockSignals(blocked)
+        self._sync_continuous_colormap_controls(continuous)
+
+    def _sync_continuous_colormap_controls(self, continuous):
+        """Keep class-count editability consistent with renderer mode."""
+        self.sb_symbol_classes.setEnabled(not bool(continuous))


### PR DESCRIPTION
This PR introduces support for continuous colormaps.

**Note:** for vector data, when a continuous colormap is used, no legend is displayed in Layers, as there is currently no clean way to represent continuous colormaps for vector layers.
